### PR TITLE
Fix local dev launch by escaping hero background

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,7 +11,10 @@ const Index = () => {
       <section className="hero-section relative overflow-hidden">
         {/* Background texture overlay */}
         <div className="absolute inset-0 opacity-5">
-          <div className="absolute inset-0 bg-[url('data:image/svg+xml,%3Csvg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cg fill="%23f5b919" fill-opacity="0.1"%3E%3Ccircle cx="30" cy="30" r="1"/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')] bg-repeat"></div>
+          <div
+            className="absolute inset-0 bg-repeat"
+            style={{ backgroundImage: "url('data:image/svg+xml,%3Csvg width=\'60\' height=\'60\' viewBox=\'0 0 60 60\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cg fill=\'none\' fill-rule=\'evenodd\'%3E%3Cg fill=\'%23f5b919\' fill-opacity=\'0.1\'%3E%3Ccircle cx=\'30\' cy=\'30\' r=\'1\'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')" }}
+          ></div>
         </div>
         
         {/* Floating elements for depth */}


### PR DESCRIPTION
## Summary
- fix malformed inline background image in `Index.tsx`

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684015ce3ff88328b19e8eac60ecb950